### PR TITLE
To resolve the issue when the cookie is at the lower end of the uint3…

### DIFF
--- a/binrpc.go
+++ b/binrpc.go
@@ -456,6 +456,17 @@ func ReadPacket(r io.Reader, expectedCookie []byte) ([]Record, error) {
 	return records, err
 }
 
+// BigCookie a workaround to get a big value
+// Return a big value
+func BigCookie() uint32 {
+	for {
+		bigv := uint32(rand.Int63())
+		if bigv > 100000000 {
+			return bigv
+		}
+	}
+}
+
 // WritePacket creates a BINRPC packet (header and payload) containing values v, and writes it to w.
 // It returns the cookie generated, or an error if one occurred.
 func WritePacket(w io.Writer, values ...interface{}) ([]byte, error) {
@@ -478,7 +489,7 @@ func WritePacket(w io.Writer, values ...interface{}) ([]byte, error) {
 		}
 	}
 
-	cookie := uint32(rand.Int63())
+	cookie := BigCookie()
 
 	sizeOfLength, totalLength := getMinBinarySizeOfInt(payload.Len())
 	sizeOfCookie := binary.Size(cookie)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/florentchauveau/go-kamailio-binrpc/v2
+module github.com/utilitywarehouse/go-kamailio-binrpc/v2
+
+go 1.14
 
 require github.com/pkg/errors v0.8.1


### PR DESCRIPTION
…2, let us use cookies that does not result in zeroes in the byte array